### PR TITLE
Added denormalization parameter to rest api

### DIFF
--- a/modules/core/Collections/Controller/RestApi.php
+++ b/modules/core/Collections/Controller/RestApi.php
@@ -44,7 +44,7 @@ class RestApi extends \LimeExtra\Controller {
             return false;
         }
 
-        $collection = $this->app->db->findOne("common/collections",  ["name"=>$collection]);
+        $collection = $this->app->db->findOne("common/collections", ["name"=>$collection]);
 
         if (!$collection) {
             return false;

--- a/modules/core/Collections/Controller/RestApi.php
+++ b/modules/core/Collections/Controller/RestApi.php
@@ -3,6 +3,40 @@
 namespace Collections\Controller;
 
 class RestApi extends \LimeExtra\Controller {
+    private function get_item_from_hash($propName, $val) {
+        static $cache = [];
+        if (substr($propName, 0, 1) != "_" && preg_match('/^[0-9a-fA-F]{24}$/', $val)) {
+            if (!array_key_exists($val, $cache)) {
+                if (!array_key_exists($propName, $cache)) {
+                    $cache[$propName] = $this->app->db->findOne("common/collections",["name"=>$propName]);
+                    $cache[$cache[$propName]["_id"]] = $cache[$propName];
+                }
+                $cache[$val] = $this->denormalize_entry($this->app->db->findOneById("collections/collection".$cache[$propName]["_id"], $val));
+            }
+            if ($cache[$val]) {
+                return $cache[$val];
+            }
+        }
+        return $val;
+    }
+
+    private function denormalize_entry($entry) {
+        if ($entry) {
+            foreach($entry as $propName => $val) {
+                // One gotcha of this function - $propName (and thus field name of collection link) must match the name of the collection a given entry belongs to. Otherwise denormalization will not know where to look for item hash and fail.
+                if(is_array($val)) {
+                    $result = $val;
+                    foreach($val as $key=>$obj_id) {
+                        $result[$key] = $this->get_item_from_hash($propName, $obj_id);
+                    }
+                    $entry[$propName] = $result;
+                } else {
+                    $entry[$propName] = $this->get_item_from_hash($propName, $val);
+                }
+            }
+        }
+        return $entry;
+    }
 
     public function get($collection=null) {
 
@@ -10,7 +44,7 @@ class RestApi extends \LimeExtra\Controller {
             return false;
         }
 
-        $collection = $this->app->db->findOne("common/collections", ["name"=>$collection]);
+        $collection = $this->app->db->findOne("common/collections",  ["name"=>$collection]);
 
         if (!$collection) {
             return false;
@@ -29,6 +63,13 @@ class RestApi extends \LimeExtra\Controller {
             if ($skip   = $this->param("skip", null))   $options["skip"] = $skip;
 
             $entries = $this->app->db->find("collections/{$col}", $options);
+        }
+
+
+        if ($this->param("denormalize")) {
+            foreach($entries as &$entry) {
+                $entry = $this->denormalize_entry($entry);
+            }
         }
 
         return json_encode($entries->toArray());


### PR DESCRIPTION
This introduces a flag parameter to the REST API that will denormalize linked collections. For instance, before a rest api call might look like:
`
/cockpit/rest/api/collections/get/MyCollection?token=xoxoxo`

`
[{
  "Name": "My Entry",
  "MyLinkedCollection": "xxxxxxxxxxxxxxxxxxxxxxxx"
}]
`

Now, we can do this:

`
/cockpit/rest/api/collections/get/MyCollection?token=xoxoxo&denormalize=true`

`
[{
  "Name": "My Entry",
  "MyLinkedCollection": {
    "Name": "MyLinkedEntry"
    "_id": "xxxxxxxxxxxxxxxxxxxxxxxx"
  }
}]
`

One problem I encountered building this feature - it appears that the collection link field does not save a reference to the collection it belongs to (that I could find anyway). So right now, the success of the denormalization step depends on the name of the field matching the name of the collection the link belongs to. So, for example, if you have a field that is a collection link to an entry from the "Animal" collection, and you name the field "My Pets," it will fail to denormalize and leave its member(s) as (a) hash(es). 