### PR TITLE
Option to set google masp API key (Cockpit-Master)

### DIFF
--- a/assets/js/angular/fields/location.js
+++ b/assets/js/angular/fields/location.js
@@ -4,8 +4,7 @@
 
 (function($){
 
-    angular.module('cockpit.fields').directive("locationfield", ['$timeout', '$compile', function($timeout, $compile){
-
+    angular.module('cockpit.fields').directive("locationfield", ['$timeout', '$compile', '$http', function($timeout, $compile, $http) {
 
         var uuid = 0,
             locale = document.documentElement.lang.toUpperCase(),
@@ -23,9 +22,14 @@
 
                             script.onload = function() {
 
-                                google.load('maps', '3', {other_params: 'sensor=false&libraries=places&language=' + locale, callback: function(){
-                                  if (google && google.maps.places) resolve();
-                                }});
+                                $http
+                                    .post(App.route('/settings/getGmapsKey'))
+                                    .success(function(key) {
+
+                                        google.load('maps', '3', {other_params: 'key=' + key + '&libraries=places&language=' + locale, callback: function() {
+                                            if (google && google.maps.places) resolve();
+                                        }});
+                                    });
                             };
 
                             script.onerror = function() {

--- a/modules/core/Cockpit/Controller/Settings.php
+++ b/modules/core/Cockpit/Controller/Settings.php
@@ -10,12 +10,13 @@ class Settings extends \Cockpit\Controller {
         $registry = json_encode((object)$this->app->memory->get("cockpit.api.registry", []));
         $tokens   = $this->app->db->getKey("cockpit/settings", "cockpit.api.tokens", null);
         $locales  = json_encode($this->app->db->getKey("cockpit/settings", "cockpit.locales", []));
+        $gmapskey = $this->app->db->getKey("cockpit/settings", "cockpit.gmaps.key", '');
 
         if (!$tokens) {
             $tokens = new \stdClass;
         }
 
-        return $this->render('cockpit:views/settings/general.php', compact('tokens', 'registry', 'locales'));
+        return $this->render('cockpit:views/settings/general.php', compact('tokens', 'registry', 'locales', 'gmapskey'));
     }
 
     public function info() {
@@ -137,5 +138,19 @@ class Settings extends \Cockpit\Controller {
         $this->app->db->setKey("cockpit/settings", "cockpit.locales", $locals);
 
         return ["success"=>true];
+    }
+
+    public function getGmapsKey() {
+
+        return $this->app->db->getKey("cockpit/settings", "cockpit.gmaps.key", '');
+    }
+
+    public function saveGmapsKey() {
+
+        $gmapskey = $this->param("key", "");
+
+        $this->app->db->setKey("cockpit/settings", "cockpit.gmaps.key", (string) $gmapskey);
+
+        return ["success" => true];
     }
 }

--- a/modules/core/Cockpit/views/settings/general.php
+++ b/modules/core/Cockpit/views/settings/general.php
@@ -14,6 +14,7 @@
             <li><a href="#LOCALES">@lang('Locales')</a></li>
             <li><a href="#REGISTRY">@lang('Registry')</a></li>
             <li><a href="#SYSTEM">@lang('API')</a></li>
+            <li><a href="#GMAPS">@lang('Google Maps')</a></li>
         </ul>
     </div>
 
@@ -168,7 +169,17 @@
                     <button class="uk-button uk-button-large" ng-click="generateToken()">@lang('Generate api token')</button>
                 </div>
 
+                <div>
+                    <span class="uk-badge app-badge">@lang('Google Maps')</span>
+                    <hr />
 
+                    <div class="uk-margin uk-form">
+                        <label class="uk-text-small">@lang('Google Maps API Key')</label>
+                        <input type="text" class="uk-form-large uk-width-1-1" ng-model="gmapskey" />
+                    </div>
+
+                    <button class="uk-button uk-button-large" type="button" ng-click="saveGmapsKey()">@lang('Save')</button>
+                </div>
             </div>
         </div>
     </div>
@@ -182,6 +193,7 @@
         $scope.tokens    = {{ json_encode($tokens) }};
         $scope.registry  = {{ $registry }};
         $scope.locales   = {{ $locales }};
+        $scope.gmapskey  = '{{ $gmapskey }}';
 
         $scope.languages = {};
 
@@ -292,6 +304,12 @@
         $scope.saveTokens = function() {
             $http.post(App.route("/settings/saveTokens"), {"tokens": angular.copy($scope.tokens)}).success(function(data){
                 App.notify("@lang('Tokens updated!')", "success");
+            }).error(App.module.callbacks.error.http);
+        };
+
+        $scope.saveGmapsKey = function() {
+            $http.post(App.route("/settings/saveGmapsKey"), {"key": $scope.gmapskey}).success(function(data) {
+                App.notify("@lang('Key updated!')", "success");
             }).error(App.module.callbacks.error.http);
         };
 


### PR DESCRIPTION
As described in [this announcement](http://googlegeodevelopers.blogspot.com.au/2016/06/building-for-scale-updates-to-google.html), Google Maps requires using API key for domains active after 22/06/2016 and localhost domain.
Without it, widget doesn't render and console shows a `MissingKeyMapError`.

I've added new tab: _Settings > General > Google Maps_ to have add an ability to specify the API key.
Data is stored under collection `cockpit/settings` and key `cockpit.gmaps.key`.

![gmapskey2](https://cloud.githubusercontent.com/assets/612953/17001533/b0b1660c-4ec7-11e6-84fb-61eff8786fff.png)

This PR concerns (old/ master) Cockpit branch, possibly similar implementation may be prepared for Cockpit Next (effort started [here](https://github.com/COCOPi/cockpit/commit/368a4d8d4f5bf277187e6b625bcfdc9d5fb021c5))