### PR TITLE
Add controls for geolocation adjustments (master branch)

### DIFF
--- a/assets/js/angular/fields/location.js
+++ b/assets/js/angular/fields/location.js
@@ -55,12 +55,43 @@
             replace     : true,
             template    : '<div>\
                                 <div class="uk-form uk-form-icon uk-margin-small-bottom uk-width-1-1">\
-                                    <i class="uk-icon-search"></i><input class="uk-width-1-1" value="{{ latlng.address }}">\
+                                    <i class="uk-icon-search"></i>\
+                                    <input class="uk-width-1-1" value="{{ latlng.address }}">\
                                 </div>\
                                 <div class="js-map" style="min-height:300px;"> \
-                                Loading map... \
-                                </div> \
-                                <div class="uk-text-small uk-margin-small-top">LAT: <span class="uk-text-muted">{{ latlng.lat }}</span> LNG: <span class="uk-text-muted">{{ latlng.lng }}</span></div> \
+                                    ' + App.i18n.get('Loading map...') + ' \
+                                </div>\
+                                <div class="uk-form uk-text-small uk-margin-small-top">\
+                                    <fieldset class="uk-float-left">\
+                                        <label>\
+                                            ' + App.i18n.get('LAT') + ':\
+                                            <input type="number" min="-90" max="90" step="any" class="uk-form-small" data-ng-model="latlng.lat" data-ng-change="onChangeCoords()" />\
+                                        </label>\
+                                        <label>\
+                                            ' + App.i18n.get('LNG') + ':\
+                                            <input type="number" min="-90" max="90" step="any" class="uk-form-small" data-ng-model="latlng.lng" data-ng-change="onChangeCoords()" />\
+                                        </label>\
+                                    </fieldset>\
+                                    <fieldset class="uk-float-right uk-form-row">\
+                                        <span class="uk-form-label">\
+                                            ' + App.i18n.get('Update address when dragging marker') + ':\
+                                        </span>\
+                                        <span class="uk-form-controls uk-form-controls-text">\
+                                            <label>\
+                                                <input name="addressReset" type="radio" data-ng-model="addressReset" value="clear" checked="checked" />\
+                                                ' + App.i18n.get('clear') + '\
+                                            </label>\
+                                            <label>\
+                                                <input name="addressReset" type="radio" data-ng-model="addressReset" value="keep" />\
+                                                ' + App.i18n.get('keep') + '\
+                                            </label>\
+                                            <label>\
+                                                <input name="addressReset" type="radio" data-ng-model="addressReset" value="geocode" />\
+                                                ' + App.i18n.get('geocode') + '\
+                                            </label>\
+                                        </span>\
+                                    </fieldset>\
+                                </div>\
                            </div>',
             link        : function (scope, elm, attrs, ngModel) {
 
@@ -69,9 +100,12 @@
                     $timeout(function() {
 
                         var map, marker, mapId = 'google-maps-location-'+(++uuid), point = new google.maps.LatLng(53.55909862554551, 9.998652343749995),
-                            input, autocomplete;
+                            input, autocomplete, geocoder;
 
                         scope.latlng = ngModel.$viewValue || {lat: point.lat(), lng: point.lng(), address: ''};
+                        scope.addressReset = 'clear';
+
+                        input = elm.find('input')[0];
 
                         elm.find('.js-map').attr('id', mapId);
 
@@ -86,20 +120,58 @@
                             draggable : true
                         });
 
+                        geocoder = new google.maps.Geocoder;
+
+                        // Change marker position using mouse
                         google.maps.event.addListener(marker, 'dragend', function() {
+
                             var point = marker.getPosition();
-                            updateScope({lat: point.lat(), lng: point.lng(), address: ''});
-                            // Reset input value (or reverse geolocate)
-                            input.value = '';
+                            map.panTo(point);
+
+                            switch (scope.addressReset) {
+                                case 'clear':
+                                    updateScope({lat: point.lat(), lng: point.lng(), address: ''});
+                                    break;
+
+                                case 'keep':
+                                    updateScope({lat: point.lat(), lng: point.lng(), address: scope.latlng.address});
+                                    break;
+
+                                case 'geocode':
+                                    geocode(geocoder, point);
+                                    break;
+                            }
                         });
+
+                        // Change marker position using inputs
+                        scope.onChangeCoords = function() {
+
+                            var point = new google.maps.LatLng(scope.latlng.lat, scope.latlng.lng);
+
+                            marker.setPosition(point);
+                            map.panTo(point);
+
+                            switch (scope.addressReset) {
+                                case 'clear':
+                                    scope.latlng.address = '';
+                                    break;
+
+                                case 'keep':
+                                    break;
+
+                                case 'geocode':
+                                    geocode(geocoder, point);
+                                    break;
+                            }
+
+                        };
 
                         jQuery.UIkit.$win.on('resize', function(){
                             google.maps.event.trigger(map,'resize');
                             map.setCenter(marker.getPosition());
                         });
 
-                        input = elm.find('input')[0];
-
+                        // Configure autocomplete
                         autocomplete = new google.maps.places.Autocomplete(input, {});
                         autocomplete.bindTo('bounds', map);
 
@@ -121,9 +193,10 @@
                             marker.setPosition(place.geometry.location);
 
                             var point = marker.getPosition();
-                            updateScope({lat: point.lat(), lng:point.lng(), address: input.value});
+                            updateScope({lat: point.lat(), lng: point.lng(), address: input.value});
                         });
 
+                        // Configure address input
                         google.maps.event.addDomListener(input, 'keydown', function(e) {
                             if (e.keyCode == 13) {
                                 e.preventDefault();
@@ -149,6 +222,14 @@
                     });
                 });
 
+                /**
+                 * Update scope with new position data
+                 *
+                 * @param {Object} latlng
+                 * @param {integer} latlng.lat
+                 * @param {integer} latlng.lng
+                 * @param {string} latlng.address
+                 */
                 function updateScope(latlng) {
 
                     ngModel.$setViewValue(latlng);
@@ -158,6 +239,26 @@
                     if (!scope.$root.$$phase) {
                         scope.$apply();
                     }
+                }
+
+                /**
+                 * Geocode point and update scope
+                 *
+                 * @param {new google.maps.Geocoder} geocoder
+                 * @param {goole.maps.LatLng} point
+                 */
+                function geocode(geocoder, point) {
+
+                    geocoder.geocode({location: point}, function(results, status) {
+
+                        var address = '';
+
+                        if (status === google.maps.GeocoderStatus.OK && results.length) {
+                            address = results[0].formatted_address;
+                        }
+
+                        updateScope({lat: point.lat(), lng: point.lng(), address: address});
+                    });
                 }
             }
         };


### PR DESCRIPTION
Sometimes Google geolocation mechanism doesn't find correct coordinates of an address.
This PR adds controls to tweak it; it adds controls to:

- Specify points' latitude and longitude using manual inputs
- Options to:
  - Keep the text address while changing point location
  - Reverse geocode (find address by points' location)

![location-manual](https://cloud.githubusercontent.com/assets/612953/18119353/86ef02da-6f5a-11e6-8430-3f8c790dc493.png)