### PR TITLE
Tweaks to importer

### DIFF
--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -3,7 +3,6 @@
     var Filter = {
 
         filter: function(field, value, extra){
-
             var _resolve, _reject, p = new Promise(function(resolve, reject) {
                 _resolve = resolve;
                 _reject = reject;
@@ -33,23 +32,23 @@
         date: function(value) {
 
             var date = new Date(value);
-   
+
             if (isNaN(date.getTime()) || !date.toISOString().match(/(.+)\T/)[1]) {
                 value = null;
             }
 
-            this.resolve(value);   
+            this.resolve(value);
         },
 
         collectionlink: function(value, field, extra) {
-
-            if (field.options && field.options.link && extra) {
-
+            if (_.isPlainObject(value)) {
+                value = value[extra];
+            }
+            if (field.options && field.options.link && extra && value) {
                 var $this = this, filter = {};
                 filter[extra] = value;
 
                 App.callmodule('collections:findOne', [field.options.link, filter]).then(function(data) {
-                    
                     if (data.result && data.result._id) {
 
                         var entry = {_id:data.result._id, display: data.result[field.options.display] || data.result[Filter.collections[field.options.link].fields[0].name] || 'n/a'};

--- a/modules/Collections/assets/import/parser.js
+++ b/modules/Collections/assets/import/parser.js
@@ -57,7 +57,7 @@
 
         json: function(content, resolve, reject) {
 
-            var data, headers = [];
+            var data;
 
             try {
                 var data = JSON.parse(content);
@@ -77,13 +77,9 @@
                 return reject('List is empty!');
             }
 
-
-            Object.keys(data[0]).forEach(function(key) {
-
-                if (['_id', '_created', '_modified'].indexOf(key) != -1) return;
-
-                headers.push(key);
-            });
+            var headers = _.reduce(data, function(result, item){
+                return _.difference(_.union(_.keys(item), result), ['_id', '_uid', '_created', '_modified']);
+            }, []);
 
             resolve({
                 headers: headers,

--- a/modules/Collections/assets/import/parser.js
+++ b/modules/Collections/assets/import/parser.js
@@ -64,7 +64,14 @@
             } catch(e) { return reject(e.message) }
 
             if (!Array.isArray(data)) {
-                return reject('JSON needs to be an array of items!');
+                if (_.isPlainObject(data)) {
+                    data = _.reduce(_.keys(data).sort(), function(result, val){
+                        result.push(data[val]);
+                        return result;
+                    }, []);
+                } else {
+                    return reject('JSON needs to be a collection of items!');
+                }
             }
 
             if (!data.length) {
@@ -77,7 +84,7 @@
 
                 headers.push(key);
             });
-            
+
             resolve({
                 headers: headers,
                 rows: data

--- a/modules/Collections/assets/import/parser.js
+++ b/modules/Collections/assets/import/parser.js
@@ -65,9 +65,8 @@
 
             if (!Array.isArray(data)) {
                 if (_.isPlainObject(data)) {
-                    data = _.reduce(_.keys(data).sort(), function(result, val){
+                    data = _.transform(_.keys(data).sort(), function(result, val){
                         result.push(data[val]);
-                        return result;
                     }, []);
                 } else {
                     return reject('JSON needs to be a collection of items!');
@@ -77,6 +76,7 @@
             if (!data.length) {
                 return reject('List is empty!');
             }
+
 
             Object.keys(data[0]).forEach(function(key) {
 


### PR DESCRIPTION
I had identified two problems with the importer:

1) It only accepted arrays, while the legacy version of Cockpit outputs objects.
2) It did not create a complete list of column headers from the input object. Previously we were only checking the first item in the collection, however the legacy version of Cockpit sometimes outputs items that do not contain keys for optional fields; some items may have keys that others do not.

These commits should address both of these issues.

Additional changes:

Under some circumstances, the importer was incorrectly establishing collection links with the first entry in the collection. That is fixed.

I have also added the ability for the collection link import filter to grab lookup value out of an object, if the same key exists there.