### PR TITLE
Add support for multiple values on collection link import

### DIFF
--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -52,7 +52,7 @@
                 }
 
                 try {
-                    value = (new Function('tag', 'return tag.'+field+'];'))(tag);
+                    value = (new Function('tag', 'return tag.'+field+';'))(tag);
                 } catch(e) {}
 
                 return value;
@@ -95,7 +95,7 @@
                         cache[field] = true;
                     }
 
-                    body = 'try{ tag.'+field+'] = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
+                    body = 'try{ tag.'+field+' = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
 
                     fn = new Function('tag', 'val', 'silent', body);
 

--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -52,7 +52,7 @@
                 }
 
                 try {
-                    value = (new Function('tag', 'return tag["'+field+'"];'))(tag);
+                    value = (new Function('tag', 'return tag.'+field+'];'))(tag);
                 } catch(e) {}
 
                 return value;
@@ -95,7 +95,7 @@
                         cache[field] = true;
                     }
 
-                    body = 'try{ tag["'+field+'"] = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
+                    body = 'try{ tag.'+field+'] = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
 
                     fn = new Function('tag', 'val', 'silent', body);
 

--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -42,7 +42,7 @@
             ele.$boundTo = tag;
 
             ele.$getValue = function(field) {
-                
+
                 field = field || ele.getAttribute(attr);
 
                 var value = null;
@@ -52,7 +52,7 @@
                 }
 
                 try {
-                    value = (new Function('tag', 'return tag.'+field+';'))(tag);
+                    value = (new Function('tag', 'return tag["'+field+'"];'))(tag);
                 } catch(e) {}
 
                 return value;
@@ -95,7 +95,7 @@
                         cache[field] = true;
                     }
 
-                    body = 'try{ tag.'+field+' = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
+                    body = 'try{ tag["'+field+'"] = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ return false; }';
 
                     fn = new Function('tag', 'val', 'silent', body);
 

--- a/modules/Collections/assets/field-collectionlink.tag
+++ b/modules/Collections/assets/field-collectionlink.tag
@@ -196,7 +196,7 @@
 
         var _entry = e.item.entry;
         var entry = {_id:_entry._id, display: _entry[opts.display] || _entry[this.collection.fields[0].name] || 'n/a'};
-    
+
         if (opts.multiple) {
             this.link.push(entry);
         } else {
@@ -312,7 +312,7 @@
         if (this.filter || load) {
 
             if (opts.filter) {
-                
+
                 Object.keys(opts.filter).forEach(function(k) {
                     switch(k) {
                         case '$and':
@@ -327,7 +327,7 @@
                             $this.filter[k] = opts.filter[k];
                     }
                 });
-                
+
                 this.filter = opts.filter;
             }
 

--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -50,7 +50,7 @@
 
                 App.callmodule('collections:findOne', [field.options.link, filter]).then(function(data) {
                     if (data.result && data.result._id) {
-
+                        //TODO add support for multiple imports
                         var entry = {_id:data.result._id, display: data.result[field.options.display] || data.result[Filter.collections[field.options.link].fields[0].name] || 'n/a'};
                         $this.resolve(field.options.multiple ? [entry]:entry);
 

--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -41,25 +41,67 @@
         },
 
         collectionlink: function(value, field, extra) {
-            if (_.isPlainObject(value) && extra) {
-                value = value[extra];
-            }
+
             if (field.options && field.options.link && extra && value) {
-                var $this = this, filter = {};
-                filter[extra] = value;
+                var $this = this;
 
-                App.callmodule('collections:findOne', [field.options.link, filter]).then(function(data) {
-                    if (data.result && data.result._id) {
-                        //TODO add support for multiple imports
-                        var entry = {_id:data.result._id, display: data.result[field.options.display] || data.result[Filter.collections[field.options.link].fields[0].name] || 'n/a'};
-                        $this.resolve(field.options.multiple ? [entry]:entry);
+                if (Array.isArray(value)) {
+                    var options = {};
+                    value = _.map(value, function(item){
+                        return _.isPlainObject(item) && extra ? item[extra] : item;
+                    });
+                    options.filter = {};
+                    options.filter["$or"] = _.map(value, function(item){
+                        var filter = {};
+                        filter[extra] = item;
+                        return filter;
+                    });
 
-                    } else {
-                        console.log("Couldn't find a collection reference for "+value);
-                        $this.resolve(null);
+                    App.callmodule('collections:find', [field.options.link, options]).then(function(data) {
+                        if (data.result && data.result.length) {
+                            if (field.options.multiple) {
+
+                                var entries = _.map(data.result, function(item){
+                                    return {
+                                        _id: item._id,
+                                        display: item[field.options.display] || item[Filter.collections[field.options.link].fields[0].name] || 'n/a'
+                                    };
+                                });
+
+                                $this.resolve(entries);
+                            } else {
+                                var entry = {
+                                    _id:data.result[0]._id,
+                                    display: data.result[0][field.options.display] || data.result[0][Filter.collections[field.options.link].fields[0].name] || 'n/a'
+                                };
+                                $this.resolve(entry);
+                            }
+                        } else {
+                            console.log("Couldn't find a collection reference for "+value.join(", "));
+                            $this.resolve(null);
+                        }
+                    });
+
+                } else {
+
+                    if (_.isPlainObject(value) && extra) {
+                        value = value[extra];
                     }
-                });
+                    var filter = {};
+                    filter[extra] = value;
+                    App.callmodule('collections:findOne', [field.options.link, filter]).then(function(data) {
+                        if (data.result && data.result._id) {
+                            //TODO add support for multiple imports
+                            var entry = {_id:data.result._id, display: data.result[field.options.display] || data.result[Filter.collections[field.options.link].fields[0].name] || 'n/a'};
+                            $this.resolve(field.options.multiple ? [entry]:entry);
 
+                        } else {
+                            console.log("Couldn't find a collection reference for "+value);
+                            $this.resolve(null);
+                        }
+                    });
+
+                }
             } else {
 
                 this.resolve(null);

--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -44,7 +44,7 @@
             if (_.isPlainObject(value) && extra) {
                 value = value[extra];
             }
-            if (field.options && field.options.link && extra && typeof value === "string") {
+            if (field.options && field.options.link && extra && value) {
                 var $this = this, filter = {};
                 filter[extra] = value;
 

--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -44,7 +44,7 @@
             if (_.isPlainObject(value) && extra) {
                 value = value[extra];
             }
-            if (field.options && field.options.link && extra && value) {
+            if (field.options && field.options.link && extra && typeof value === "string") {
                 var $this = this, filter = {};
                 filter[extra] = value;
 

--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -41,7 +41,7 @@
         },
 
         collectionlink: function(value, field, extra) {
-            if (_.isPlainObject(value)) {
+            if (_.isPlainObject(value) && extra) {
                 value = value[extra];
             }
             if (field.options && field.options.link && extra && value) {

--- a/modules/Collections/views/import/collection.php
+++ b/modules/Collections/views/import/collection.php
@@ -54,7 +54,7 @@
     </div>
 
     <div name="step2" data-step="1" show="{step==2}">
-        
+
         <h2>{ file.name }</h2>
         <div class="uk-margin uk-text-muted">{ data.rows.length } @lang('Entries found.')</div>
 
@@ -77,7 +77,7 @@
                     <td>
                         <div class="uk-form-select">
                             <a class="{ parent.mapping[field.name] ? 'uk-link-muted':''}"><i class="uk-icon-exchange" show="{parent.mapping[field.name]}"></i> { parent.mapping[field.name] || 'Select...'}</a>
-                            <select class="uk-width-1-1" bind="mapping.{field.name}">
+                            <select class="uk-width-1-1" bind="mapping['{field.name}']">
                                 <option></option>
                                 <option each="{h,hidx in data.headers}" value="{h}">{h}</option>
                             </select>
@@ -87,16 +87,16 @@
                             @lang('Match against:')
                             <div class="uk-form-select">
                                 {field.options.link}.<a>{parent.filterData[field.name] || '(Select field...)'}</a>
-                                <select bind="filterData.{field.name}">
+                                <select bind="filterData['{field.name}']">
                                     <option value=""></option>
                                     <option value="{f.name}" each="{f in _COL_[field.options.link].fields}">{f.name}</option>
                                 </select>
                             </div>
-                        </div> 
+                        </div>
                     </td>
                     <td>
                         <div class="uk-text-center">
-                            <input type="checkbox" bind="filter.{field.name}" />
+                            <input type="checkbox" bind="filter['{field.name}']" />
                         </div>
                     </td>
                 </tr>
@@ -160,7 +160,7 @@
             this.mapping = {};
             this.filter = {};
             this.filterData = {};
-            
+
             this.step = 1;
             this.step1.classList.remove('uk-dragover');
         }
@@ -177,16 +177,17 @@
             this.update();
 
             ImportParser.parse(file).then(function(data) {
-                
+
                 $this.data = data;
 
                 // auto-map fields
                 $this.fields.forEach(function(f){
                     if (data.headers.indexOf(f.name) != -1) {
+                        debugger;
                         $this.mapping[f.name] = f.name;
                     }
                 });
-                
+
                 $this.file = file;
                 $this.step = 2;
                 $this.update();
@@ -281,7 +282,7 @@
                             entry = {};
 
                             Object.keys($this.mapping).forEach(function(k, val, d){
-                                
+
                                 val = c[$this.mapping[k]];
                                 d   = $this.filterData[k];
 
@@ -289,6 +290,8 @@
                                     promises.push(ImportFilter.filter(fields[k], val, d).then(function(val){
                                         entry[k] = val;
                                     }));
+                                // } else if (_.isPlainObject(val)) {
+                                //     entry[k] = val.type == fields[k].type ? val : null;
                                 } else {
                                     entry[k] = val;
                                 }
@@ -300,13 +303,13 @@
                         Promise.all(promises).then(function(){
 
                             App.callmodule('collections:save',[$this.collection.name, entries]).then(function(data) {
-                                
+
                                 progress += cnt;
 
                                 if (progress > $this.data.rows.length) {
                                     progress = $this.data.rows.length;
                                 }
-                                
+
                                 $this.progress.innerHTML = Math.ceil((progress/$this.data.rows.length)*100)+' %';
 
                                 if (progress == $this.data.rows.length) {
@@ -318,7 +321,7 @@
                                 resolve(data && data.result);
                             });
                         }, function(msg) {
-                            
+
                             App.ui.notify(msg, "danger");
 
                             progress += cnt;
@@ -326,7 +329,7 @@
                             if (progress > $this.data.rows.length) {
                                 progress = $this.data.rows.length;
                             }
-                            
+
                             $this.progress.innerHTML = Math.ceil((progress/$this.data.rows.length)*100)+' %';
 
                             if (progress == $this.data.rows.length) {

--- a/modules/Collections/views/import/collection.php
+++ b/modules/Collections/views/import/collection.php
@@ -289,9 +289,7 @@
                                     promises.push(ImportFilter.filter(fields[k], val, d).then(function(val){
                                         entry[k] = val;
                                     }));
-                                } else if (_.isPlainObject(val)) {
-                                    entry[k] = val.type == fields[k].type ? val : null;
-                                } else {
+                                } else if (typeof val === "string") {
                                     entry[k] = val;
                                 }
                             });

--- a/modules/Collections/views/import/collection.php
+++ b/modules/Collections/views/import/collection.php
@@ -183,7 +183,6 @@
                 // auto-map fields
                 $this.fields.forEach(function(f){
                     if (data.headers.indexOf(f.name) != -1) {
-                        debugger;
                         $this.mapping[f.name] = f.name;
                     }
                 });
@@ -290,8 +289,8 @@
                                     promises.push(ImportFilter.filter(fields[k], val, d).then(function(val){
                                         entry[k] = val;
                                     }));
-                                // } else if (_.isPlainObject(val)) {
-                                //     entry[k] = val.type == fields[k].type ? val : null;
+                                } else if (_.isPlainObject(val)) {
+                                    entry[k] = val.type == fields[k].type ? val : null;
                                 } else {
                                     entry[k] = val;
                                 }

--- a/modules/Collections/views/import/collection.php
+++ b/modules/Collections/views/import/collection.php
@@ -281,15 +281,17 @@
                             entry = {};
 
                             Object.keys($this.mapping).forEach(function(k, val, d){
-
                                 val = c[$this.mapping[k]];
+                                
                                 d   = $this.filterData[k];
 
                                 if ($this.filter[k]) {
                                     promises.push(ImportFilter.filter(fields[k], val, d).then(function(val){
                                         entry[k] = val;
                                     }));
-                                } else if (typeof val === "string") {
+                                } else if (_.isObject(val)) {
+                                    entry[k] = val.type == fields[k].type ? val : null;
+                                } else {
                                     entry[k] = val;
                                 }
                             });


### PR DESCRIPTION
This adds the ability for the importer to accept an array of values for it to lookup and establish collection links for. 

It also adds a fix for localized fields of language values that contain a '-' character, and are thus not valid javascript variable names. This was affecting the bindings for select elements for localized fields.