### PR TITLE
added support for associative languages array in confg

### DIFF
--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -92,11 +92,11 @@
                     <div class="uk-width-1-1 uk-form-select">
 
                         <label class="uk-text-small">@lang('Language')</label>
-                        <div class="uk-margin-small-top">{ lang || 'Default' }</div>
+                        <div class="uk-margin-small-top">{ languageNames[lang] || lang || 'Default' }</div>
 
                         <select bind="lang">
                             <option value="">@lang('Default')</option>
-                            <option each="{language,idx in languages}" value="{language}">{language}</option>
+                            <option each="{language,idx in languages}" value="{language}">{ languageNames[language] || language}</option>
                         </select>
                     </div>
 
@@ -127,7 +127,10 @@
 
         this.entry        = {{ json_encode($entry) }};
 
-        this.languages    = App.$data.languages;
+        var langsAreNamed = !Array.isArray(App.$data.languages);
+        this.languages = langsAreNamed ? _.values(App.$data.languages) : App.$data.languages;
+        this.languageNames = langsAreNamed ? _.invert(App.$data.languages) : {};
+
         this.groups       = {main:[]};
         this.group        = 'main';
 

--- a/modules/Collections/views/import/collection.php
+++ b/modules/Collections/views/import/collection.php
@@ -140,8 +140,8 @@
 
             if (field.localize && App.$data.languages) {
 
-                App.$data.languages.forEach(function(lang, f) {
-
+                _.forEach(App.$data.languages, function(lang, f) {
+                    
                     f = App.$.extend({}, field);
 
                     f.name = f.name+'_'+lang;
@@ -282,7 +282,7 @@
 
                             Object.keys($this.mapping).forEach(function(k, val, d){
                                 val = c[$this.mapping[k]];
-                                
+
                                 d   = $this.filterData[k];
 
                                 if ($this.filter[k]) {

--- a/modules/Regions/views/form.php
+++ b/modules/Regions/views/form.php
@@ -126,7 +126,7 @@
 
             this.data      = this.region.data || {};
 
-            this.languages = App.$data.languages;
+            this.languages = Array.isArray(App.$data.languages) ? App.$data.languages :  _.values(App.$data.languages);
             this.groups       = {main:[]};
             this.group        = 'main';
 


### PR DESCRIPTION
This allows for language config like:
```
"languages" => [
        "German"=>"de",
        "Spanish"=>"es"
]
```
The key will show up in the select while the value continues to be used internally.