### PR TITLE
Fixed Collections.filterNonLinkFields which was preventing populate from working.

### DIFF
--- a/modules/Collections/bootstrap.php
+++ b/modules/Collections/bootstrap.php
@@ -441,7 +441,7 @@ $this->module("collections")->extend([
 
         return array_filter($fields, function($field) {
 
-            if (in_array($field['type'], ['collectionlink','repeater', 'set'])) {
+            if (!in_array($field['type'], ['collectionlink','repeater', 'set'])) {
                 return false;
             }
 


### PR DESCRIPTION
I think this must have just been a typo, its working fine after this change.