### PR TITLE
Add hasaccess check in forms dashboard widget

### DIFF
--- a/modules/Forms/views/widgets/dashboard.php
+++ b/modules/Forms/views/widgets/dashboard.php
@@ -47,7 +47,11 @@
                     <img src="@url('forms:icon.svg')" width="30" height="30" alt="Forms" data-uk-svg />
                 </p>
 
-                @lang('No forms'). <a href="@route('/forms/form')">@lang('Create a form')</a>.
+                @lang('No forms'). 
+
+                @hasaccess?('forms', 'create')
+                <a href="@route('/forms/form')">@lang('Create a form')</a>.
+                @end
 
             </div>
 


### PR DESCRIPTION
ATM forms widget shows an action _Create a collection_ even if user doesn't have rights to create one.

PR adds similar check like how it's done in other modules widgets (for example [in collections](https://github.com/COCOPi/cockpit/blob/next/modules/Collections/views/widgets/dashboard.php#L60-L64)).