### PR TITLE
Extra smtp options

### DIFF
--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -62,6 +62,11 @@ class Mailer {
             if(isset($this->options['encryption']) && $this->options['encryption']) {
                 $mail->SMTPSecure = $this->options['encryption']; // Enable encryption: 'ssl' , 'tls' accepted
             }
+
+            // Extra smtp options
+            if (isset($this->options['smtp']) && is_array($this->options['smtp'])) {
+                $mail->SMTPOptions = $this->options['smtp'];
+            }
         }
 
         $mail->Subject = $subject;


### PR DESCRIPTION
As described in the [PHPMailer wiki](https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#php-56-certificate-verification-failure) mail may not be send due to invalid host SSL certificate.

I've added new key `smtp` in configuration so it's possible to configure sockets to ignore peer verification.

```php
return [
    'mailer' => [
        // Mailer configuration
        'transport'  => 'smtp',
        // Extra smtp configuration
        'smtp' => [
            // Disable verification
            'ssl' => [
                'verify_peer' => false,
                'verify_peer_name' => false,
                'allow_self_signed' => true,
            ]
        ]
    ]
];
```

This solves https://github.com/COCOPi/cockpit/issues/333, but one have to use above settings