### PR TITLE
fix riot dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 
     "devDependencies": {
         "less": "^2.6.0",
-        "riot": "^3.0.0",
+        "riot-cli": "^3.0.0",
         "watch-run": "^1.2.4"
     }
 }


### PR DESCRIPTION
otherwise it's depending on the implementation of resolving and installing libraries (not working with yarn and some npm versions, because the `riot` binary can not be found)