### PR TITLE
Zontar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /addons/*/*
 /tests/*
 /node_modules
-
+addons/
 !.gitignore
 !.gitkeep
 !/storage/*/index.html

--- a/addons/.gitignore
+++ b/addons/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore 

--- a/addons/.gitignore
+++ b/addons/.gitignore
@@ -1,2 +1,2 @@
 *
-!.gitignore 
+!.gitignore

--- a/modules/Cockpit/Helper/Revisions.php
+++ b/modules/Cockpit/Helper/Revisions.php
@@ -15,7 +15,7 @@ class Revisions extends \Lime\Helper {
         return $this->storage->count("cockpit/revisions", ["_oid" => $id]);
     }
 
-    public function list($id) {
+    public function revlist($id) {
 
         return $this->storage->find("cockpit/revisions", [
             "filter" => ["_oid" => $id],

--- a/modules/Cockpit/Helper/Revisions.php
+++ b/modules/Cockpit/Helper/Revisions.php
@@ -15,7 +15,7 @@ class Revisions extends \Lime\Helper {
         return $this->storage->count("cockpit/revisions", ["_oid" => $id]);
     }
 
-    public function revlist($id) {
+    public function getList($id) {
 
         return $this->storage->find("cockpit/revisions", [
             "filter" => ["_oid" => $id],

--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -268,7 +268,7 @@ class Admin extends \Cockpit\AuthController {
             return false;
         }
 
-        $revisions = $this->app->helper('revisions')->list($id);
+        $revisions = $this->app->helper('revisions')->revlist($id);
 
         
         return $this->render('collections:views/revisions.php', compact('collection', 'entry', 'revisions'));

--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -268,7 +268,7 @@ class Admin extends \Cockpit\AuthController {
             return false;
         }
 
-        $revisions = $this->app->helper('revisions')->revlist($id);
+        $revisions = $this->app->helper('revisions')->getList($id);
 
         
         return $this->render('collections:views/revisions.php', compact('collection', 'entry', 'revisions'));


### PR DESCRIPTION
The new revisions feature breaks my installation: depending on the PHP parameters it can stop the page from working, or the error can appear on the page, as on my local machine. 
The error is the one reported in the issue #544 
I've changed the name of th method `list` in Revisions to avoid this.

Since I'm also working on an add on for Cockpit-next, I had to correct the .gitignore to exclude the addons dir entirely. 