### PR TITLE
Fix entries localization

### DIFF
--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -51,15 +51,9 @@
                     return;
                 }
 
-                var lastObject = tag;
                 var segments = field.split('.');
+                var lastObject = getLastObject(tag, segments);
 
-                // Retrieve last object by segments
-                for (var j = 0; j < segments.length - 1; j++) {
-                  lastObject = lastObject[segments[j]];
-                }
-
-                // Get value by referring last segment of object
                 return lastObject[segments[segments.length - 1]];
             };
 
@@ -101,14 +95,8 @@
                     }
 
                     try {
-
-                        var lastObject = tag;
                         segments = field.split('.');
-
-                        // Retrieve last object by segments
-                        for (var j = 0; j < segments.length - 1; j++) {
-                            lastObject = lastObject[segments[j]];
-                        }
+                        var lastObject = getLastObject(tag, segments);
 
                         // Set value by referring to last segment of object
                         lastObject[segments[segments.length - 1]] = value;
@@ -218,6 +206,33 @@
             update();
         };
     };
+
+    /**
+     * Retrieve last object in by segments (helper)
+     * @param {Tag} tag
+     * @param {array} segments
+     * @return {Object}
+     */
+    function getLastObject(tag, segments) {
+
+        var lastObject = tag;
+
+        for (var i = 0, arrayString; i < segments.length - 1; i++) {
+
+            // Match format `fields[0]`
+            arrayString = segments[i].match(/^(.+)\[(\d+)\]$/);
+
+            // It's a key with an array
+            if (arrayString) {
+                lastObject = lastObject[arrayString[1]][arrayString[2]];
+            // It's a key
+            } else {
+                lastObject = lastObject[segments[i]];
+            }
+        }
+
+        return lastObject;
+    }
 
     var Mixin = {
         init: function() {

--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -51,14 +51,19 @@
                     return;
                 }
 
-                try {
-                    value = (new Function('tag', 'return tag.'+field+';'))(tag);
-                } catch(e) {}
+                var lastObject = tag;
+                var segments = field.split('.');
 
-                return value;
+                // Retrieve last object by segments
+                for (var j = 0; j < segments.length - 1; j++) {
+                  lastObject = lastObject[segments[j]];
+                }
+
+                // Get value by referring last segment of object
+                return lastObject[segments[segments.length - 1]];
             };
 
-            ele.$setValue = (function(fn, body) {
+            ele.$setValue = (function() {
 
                 var field, segments, cache = {};
 
@@ -95,11 +100,33 @@
                         cache[field] = true;
                     }
 
-                    body = 'try{ tag.'+field+' = val; if(!silent) { tag.update(); } tag.trigger("bindingupdated", ["'+field+'", val]);return true;}catch(e){ console.log(e);return false; }';
+                    try {
 
-                    fn = new Function('tag', 'val', 'silent', body);
+                        var lastObject = tag;
+                        segments = field.split('.');
 
-                    return fn(tag, value, silent);
+                        // Retrieve last object by segments
+                        for (var j = 0; j < segments.length - 1; j++) {
+                            lastObject = lastObject[segments[j]];
+                        }
+
+                        // Set value by referring to last segment of object
+                        lastObject[segments[segments.length - 1]] = value;
+
+                        if (!silent) {
+                            tag.update();
+                        }
+
+                        tag.trigger('bindingupdated', ['"' + field + '"', value]);
+
+                        return true;
+
+                    } catch (e) {
+
+                        console.log(e);
+
+                        return false;
+                    }
                 };
 
             })();

--- a/assets/lib/riot/riot.bind.js
+++ b/assets/lib/riot/riot.bind.js
@@ -51,10 +51,7 @@
                     return;
                 }
 
-                var segments = field.split('.');
-                var lastObject = getLastObject(tag, segments);
-
-                return lastObject[segments[segments.length - 1]];
+                return _.get(tag, field);
             };
 
             ele.$setValue = (function() {
@@ -95,11 +92,7 @@
                     }
 
                     try {
-                        segments = field.split('.');
-                        var lastObject = getLastObject(tag, segments);
-
-                        // Set value by referring to last segment of object
-                        lastObject[segments[segments.length - 1]] = value;
+                        _.set(tag, field, value);
 
                         if (!silent) {
                             tag.update();
@@ -206,33 +199,6 @@
             update();
         };
     };
-
-    /**
-     * Retrieve last object in by segments (helper)
-     * @param {Tag} tag
-     * @param {array} segments
-     * @return {Object}
-     */
-    function getLastObject(tag, segments) {
-
-        var lastObject = tag;
-
-        for (var i = 0, arrayString; i < segments.length - 1; i++) {
-
-            // Match format `fields[0]`
-            arrayString = segments[i].match(/^(.+)\[(\d+)\]$/);
-
-            // It's a key with an array
-            if (arrayString) {
-                lastObject = lastObject[arrayString[1]][arrayString[2]];
-            // It's a key
-            } else {
-                lastObject = lastObject[segments[i]];
-            }
-        }
-
-        return lastObject;
-    }
 
     var Mixin = {
         init: function() {


### PR DESCRIPTION
At this moment it's not possible to localize entry values (at least in Chrome v58.0.3029.110)
When switching to other language, values stay the same and in database are stored under same keys.

I've tracked the problem down to [assets/lib/riot/riot.bind.js](https://github.com/COCOPi/cockpit/blob/next/assets/lib/riot/riot.bind.js) library.

For some reasons accessing the tag values as dot-separated-keys using current method (eval) the didn't work properly. Switching to non-eval method fixed the issue. Unfortunately I'm not able to explain why.

Steps to reproduce:
1) Add new language in config
2) Create new Collection (Post template) and set some fields as Localized
3) Create new entry, fill out localized fields
4) Switch language (value that are supposed to be localized should clear up)
5) Save (localized values should be stored in database)